### PR TITLE
Fix #1

### DIFF
--- a/src/shipworksASM.asm
+++ b/src/shipworksASM.asm
@@ -52,8 +52,15 @@ CreateLibrary PROC
     push rbx
     mov rbx, [rcx]
     test rbx, rbx
+    jmp noDeconstruct
     jz noDeconstruct
     mov rax, [rbx]
+    ;; This calls the function at 14025e320, which reads the vftable at rcx
+    ;; (which normally is just the vftable of the object that called it) and
+    ;; calls the function at 14025E330, which I'm not sure what it does. When
+    ;; using the modloader rcx is a garbage value, causing it to try calling
+    ;; into random memory. For now I'm just skipping calling this function, as
+    ;; it doesn't seem to affect the game at all.
     call qword ptr [rax+48h]
 noDeconstruct:
     ;; Save our parameters


### PR DESCRIPTION
This is a very dumb fix, but it works while my understanding of the game code is still low. The game before assigning all of the parts of the library checks if that library exists already in memory, if it does it will call a class function that seems to pertain to the objects properties.

If the modloader was active this function would fail because the this pointer would be garbage when calling it. To circumvent this I simply don't call the function anymore. A better fix would be to investigate why the this pointer is malformed or only call the function when it's the expected value (I would assume the global library would always be the correct one?)

This fixes #1
Further investigation is needed to determine if this affects #2 too, as I have a suspicion that it might.